### PR TITLE
overflow exception after long sleep

### DIFF
--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -555,9 +555,16 @@ class Keyboard:
 
                     if self.verbose:
                         keydown_time = matrix.get_keydown_time(key)
-                        dt = ms(matrix.time() - keydown_time)
-                        dt2 = ms(keydown_time - last_time)
-                        last_time = keydown_time
+                        dt = 0
+                        dt2 = 0
+                        try:
+                            dt = ms(matrix.time() - keydown_time)
+                            dt2 = ms(keydown_time - last_time)
+                        except OverflowError:
+                            print('An exception flew by!')
+                        finally:    
+                            last_time = keydown_time
+
                         print(
                             "{} {} \\ {} latency {} | {}".format(
                                 key, key_name(key), hex(action_code), dt, dt2


### PR DESCRIPTION
after a longtime sleep,
the keyboard will occur an overflow exception when tapping any key.

seems to be the micropy problem.

but there's a workaround.
